### PR TITLE
Update activity and BaseApp

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,0 +1,27 @@
+# Words Activity Flatpak
+
+Words activity is a multilingual dictionary activity for the Sugar environment.
+
+To know more refer https://github.com/sugarlabs/words-activity
+
+## How To Build
+
+```
+git clone https://github.com/flathub/org.sugarlabs.Words.git
+cd org.sugarlabs.Words
+flatpak -y --user install org.gnome.{Platform,Sdk}//44
+flatpak-builder --user --force-clean --install build org.sugarlabs.Words.json
+```
+
+## Check For Updates
+
+Install the flatpak external data checker
+```
+flatpak --user install org.flathub.flatpak-external-data-checker
+```
+
+Now to update every single module to the latest stable version use
+```
+cd org.sugarlabs.Words
+flatpak run --filesystem=$PWD org.flathub.flatpak-external-data-checker org.sugarlabs.Words.json
+```

--- a/org.sugarlabs.Words.json
+++ b/org.sugarlabs.Words.json
@@ -34,8 +34,12 @@
                 {
                     "type": "git",
                     "url": "https://github.com/espeak-ng/espeak-ng.git",
-                    "tag": "1.49.2",
-                    "commit": "3ed34d3a74eb69cedcdfa98dbedef4359279d352"
+                    "tag": "1.51",
+                    "commit": "2e9a5fccbb0095e87b2769e9249ea1f821918ecd",
+                    "x-checker-data": {
+                        "type": "git",
+                        "tag-pattern": "^([\\d.]+)$"
+                    }
                 }
             ],
             "post-install": [

--- a/org.sugarlabs.Words.json
+++ b/org.sugarlabs.Words.json
@@ -65,7 +65,11 @@
                     "type": "git",
                     "url": "https://github.com/sugarlabs/words-activity.git",
                     "tag": "v24",
-                    "commit": "723bca602d3ea1dff58476dcb20c4408e5639934"
+                    "commit": "723bca602d3ea1dff58476dcb20c4408e5639934",
+                    "x-checker-data": {
+                        "type": "git",
+                        "tag-pattern": "^v([\\d.]+)$"
+                    }
                 },
                 {
                     "type": "patch",

--- a/org.sugarlabs.Words.json
+++ b/org.sugarlabs.Words.json
@@ -54,7 +54,7 @@
                 {
                     "type": "git",
                     "url": "https://github.com/sugarlabs/gst-plugins-espeak.git",
-                    "commit": "b8e815a1b8ca1468d92ab8631779e3ee3d832613"
+                    "commit": "7f6e41274fb833a487a7ee8ac0c236f0821330cc"
                 }
             ]
         },

--- a/org.sugarlabs.Words.json
+++ b/org.sugarlabs.Words.json
@@ -74,6 +74,10 @@
                 {
                     "type": "patch",
                     "path": "words-info.patch"
+                },
+                {
+                    "type": "patch",
+                    "path": "words-webkitfix.patch"
                 }
             ],
             "post-install": [

--- a/org.sugarlabs.Words.json
+++ b/org.sugarlabs.Words.json
@@ -1,9 +1,9 @@
 {
     "app-id": "org.sugarlabs.Words",
     "base": "org.sugarlabs.BaseApp",
-    "base-version": "22.06",
+    "base-version": "23.06",
     "runtime": "org.gnome.Platform",
-    "runtime-version": "42",
+    "runtime-version": "44",
     "sdk": "org.gnome.Sdk",
     "separate-locales": false,
     "command": "sugarapp",

--- a/words-webkitfix.patch
+++ b/words-webkitfix.patch
@@ -1,0 +1,13 @@
+diff --git a/wordsactivity.py b/wordsactivity.py
+index 5ce524d..85c60f1 100644
+--- a/wordsactivity.py
++++ b/wordsactivity.py
+@@ -20,7 +20,7 @@
+ import gi
+ gi.require_version('Gdk', '3.0')
+ gi.require_version('Gtk', '3.0')
+-gi.require_version('WebKit2', '4.0')
++gi.require_version('WebKit2', '4.1')
+ 
+ from gi.repository import GLib
+ from gi.repository import GObject


### PR DESCRIPTION
@tchx84 I had to make a patch after upgrading to 23.06 to resolve
`ValueError: Namespace WebKit2 not available for version 4.0`
So I replaced WebKit2 version with 4.1 and it works as expected now.